### PR TITLE
Update dfx.json

### DIFF
--- a/motoko/dfx.json
+++ b/motoko/dfx.json
@@ -1,6 +1,6 @@
 {
   "canisters": {
-    "nft": {
+    "token_ERC721": {
       "main": "src/main.mo",
       "type": "motoko"
     }


### PR DESCRIPTION
This pull request is made to rename canister name in `dfx.json` due to the following:

The canister name mentioned in `start.sh` and `demo.sh` is `token_ERC721`, however, the canister name in `dfx.json` was `nft`.

Due to this, `start.sh` and `demo.sh` were failing.